### PR TITLE
Configure DbContext for migrations

### DIFF
--- a/BervProject.WebApi.Boilerplate/Data/DesignTimeDbContextFactory.cs
+++ b/BervProject.WebApi.Boilerplate/Data/DesignTimeDbContextFactory.cs
@@ -1,0 +1,22 @@
+using BervProject.WebApi.Boilerplate.EntityFramework;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace BervProject.WebApi.Boilerplate.Data;
+
+public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<BoilerplateDbContext>
+{
+    public BoilerplateDbContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<BoilerplateDbContext>();
+        optionsBuilder.UseNpgsql(configuration.GetConnectionString("BoilerplateConnectionString"));
+
+        return new BoilerplateDbContext(optionsBuilder.Options);
+    }
+}

--- a/BervProject.WebApi.Boilerplate/Data/DesignTimeDbContextFactory.cs
+++ b/BervProject.WebApi.Boilerplate/Data/DesignTimeDbContextFactory.cs
@@ -2,6 +2,8 @@ using BervProject.WebApi.Boilerplate.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
 
 namespace BervProject.WebApi.Boilerplate.Data;
 

--- a/BervProject.WebApi.Boilerplate/EntityFramework/BoilerplateDbContext.cs
+++ b/BervProject.WebApi.Boilerplate/EntityFramework/BoilerplateDbContext.cs
@@ -1,4 +1,5 @@
-﻿using BervProject.WebApi.Boilerplate.Entities;
+using System;
+using BervProject.WebApi.Boilerplate.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace BervProject.WebApi.Boilerplate.EntityFramework

--- a/BervProject.WebApi.Boilerplate/EntityFramework/BoilerplateDbContext.cs
+++ b/BervProject.WebApi.Boilerplate/EntityFramework/BoilerplateDbContext.cs
@@ -35,6 +35,22 @@ namespace BervProject.WebApi.Boilerplate.EntityFramework
         }
 
         /// <summary>
+        /// Configure DbContext for migrations
+        /// </summary>
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__BoilerplateConnectionString");
+                if (string.IsNullOrEmpty(connectionString))
+                {
+                    connectionString = "Host=localhost;Database=testdb;Username=postgres;Password=postgres";
+                }
+                optionsBuilder.UseNpgsql(connectionString);
+            }
+        }
+
+        /// <summary>
         /// Adding relationship
         /// </summary>
         /// <param name="modelBuilder"></param>


### PR DESCRIPTION
Added configuration for DbContext to handle migrations and set a default connection string.